### PR TITLE
Make package build in Release, and clean up intemediate cargo stuff afterward

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "neon-cli": "^0.4.0"
   },
   "scripts": {
-    "install": "neon build"
+    "install": "neon build --release",
+    "postinstall": "cd native && cargo clean"
   },
   "directories": {
     "lib": "lib"


### PR DESCRIPTION
I noticed that the default `neon build` leaves the `target` folder with its ~60MB of random artifacts lying around. No reason to leave that clogging of the already huge `node_modules`.